### PR TITLE
Fix: Processed Text Preview Bug

### DIFF
--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -120,6 +120,10 @@ if st.button("🔍 Analyze News", use_container_width=True):
 
             with st.expander("View Detailed Analysis"):
                 st.write("**Processed Text Preview:**")
-                st.caption(result.get("processed_text", "Not available")[:500] + "...")
+                if "processed_text" in result:
+                    st.caption(result["processed_text"][:500] + "...")
+                else:
+                    st.caption("Not available")
+
                 st.write("**Probability Breakdown:**")
                 st.json(result.get("probabilities", {}))

--- a/scripts/data_processing.py
+++ b/scripts/data_processing.py
@@ -76,6 +76,7 @@ def preprocess_text(text):
 # Step 3: Preprocessing workflow for full DataFrame
 def preprocess_data(df):
     print("\n🧹 Preprocessing data...")
+    start = time()
 
     raw_path = DATA_RAW / "raw_combined.csv"
     df.to_csv(raw_path, index=False)

--- a/scripts/predict.py
+++ b/scripts/predict.py
@@ -43,7 +43,8 @@ def predict(title, text):
         "probabilities": {
             "Real": round(proba[0], 4),
             "Fake": round(proba[1], 4)
-        }
+        },
+        "processed_text": processed
     }
 
 # An optional test run


### PR DESCRIPTION
## 🔀 Pull Request: Processed Text Preview Bug

## ✅ Changes Made

* Enhanced the `predict()` function to return the actual **preprocessed text** used during inference.
* Ensured `processed_text` is consistently passed from `preprocess_text()` and surfaced in the output dictionary.
* Updated `streamlit_app.py` to render the preview in the “View Detailed Analysis” section under an expander.

---

## 🧠 Why This Matters

* Previously, the **Processed Text Preview** in the Streamlit UI always showed `Not available`.
* This was due to `processed_text` not being returned from the `predict()` function.
* With this fix, users can now **transparently view the tokens** the model actually used for prediction, improving trust and explainability.

---

## 💡 UX Impact

* The “View Detailed Analysis” expander now shows the actual cleaned + lemmatized text.
* Makes it easier to debug or interpret how the model tokenized the user’s input.

---

## 🛠️ Example Output

```json
{
  "label": "Fake",
  "confidence": "94.2%",
  "probabilities": {
    "Real": 0.058,
    "Fake": 0.942
  },
  "processed_text": "nasa confirm moon base construct plan launch mission 2026"
}
```

---

## 📌 Branch

`fix/processed-text-preview` → `main`